### PR TITLE
Eliminate colour flash in dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
         html,
         body {
-            background-color: #4A4A4A;
+            background-color: #202020;
         }
     }
 </style>

--- a/index.html
+++ b/index.html
@@ -3,14 +3,16 @@
 <link rel="icon" href="icons/favicons/dark.ico">
 <script src="index.js"></script>
 <style>
-html,
-body {
-    background-color: #f7f7f7;
-}
-@media (prefers-color-scheme: dark) {
     html,
     body {
-        background-color: #333333;
+        background-color: #f7f7f7;
     }
-}
+
+    @media (prefers-color-scheme: dark) {
+
+        html,
+        body {
+            background-color: #333333;
+        }
+    }
 </style>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
         html,
         body {
-            background-color: #333333;
+            background-color: #4A4A4A;
         }
     }
 </style>


### PR DESCRIPTION
When opening a new tab, there is a very brief while loading the index.html, which then causes a colour change creating visible a "flash".

This PR changes the "dark" themes colour to the base panel's colour eliminating the colour change.